### PR TITLE
CreateDataSourceのリンク切れ修正

### DIFF
--- a/en/InfoMotion/CreateDataSource.md
+++ b/en/InfoMotion/CreateDataSource.md
@@ -18,4 +18,4 @@ Available datasources for InfoMotion:
 - [Milkcocoa](./DataSource/Milkcocoa/CreateDataSource.md)
 - [Pubnub](./DataSource/Pubnub/CreateDataSource.md)
 - [Firebase](./DataSource/Firebase/CreateDataSource.md)
-- [API Gateway](./DataSource/APIGateway/CreateDataSource.md)
+- [API Gateway](./DataSource/ApiGateway/CreateDataSource.md)

--- a/ja/InfoMotion/CreateDataSource.md
+++ b/ja/InfoMotion/CreateDataSource.md
@@ -21,4 +21,4 @@ DataSource には以下が利用可能です。詳細は各ページを参照し
 - [Milkcocoa](./DataSource/Milkcocoa/CreateDataSource.md)
 - [Pubnub](./DataSource/Pubnub/CreateDataSource.md)
 - [Firebase](./DataSource/Firebase/CreateDataSource.md)
-- [API Gateway](./DataSource/APIGateway/CreateDataSource.md)
+- [API Gateway](./DataSource/ApiGateway/CreateDataSource.md)


### PR DESCRIPTION
- File deployは本スプリントではリリースしないことに決定したため、該当するドキュメントを除いた(https://bitbucket.org/technicalrockstars/enebular-product-backlog/issues/414/other-asset-deploy)

- DataSourceのリンク切れの修正のコミットのみ取り込んでいます。
(https://bitbucket.org/technicalrockstars/enebular-product-backlog/issues/409/docs-datasource)