### PR TITLE
enebular 2.5.3 release notes

### DIFF
--- a/en/Releases/enebular/2.5.3.md
+++ b/en/Releases/enebular/2.5.3.md
@@ -11,7 +11,7 @@ lastUpdated: 2018-11-09
 ## Fixed
 
 - Fixed the issue that caused the date picker on InfoMotion dashboard to become blank by double clicking it causing it unable to use as the result.
-- Fixed the issue which caused a deploy error when an attempt was made to deploy a flow to heroku.
+- Fixed the issue that caused the deploy-to-heroku attempt to fail because [the default version of Node.js on Heroku was updated to 10](https://devcenter.heroku.com/changelog-items/1508) by specifying the Node.js version to 8.12 when enebular deploys a flow to Heroku.
 
 ## Changed
 

--- a/en/Releases/index.md
+++ b/en/Releases/index.md
@@ -13,7 +13,7 @@ lastUpdated: 2018-11-09
 ### Fixed
 
 - Fixed the issue that caused the date picker on InfoMotion dashboard to become blank by double clicking it causing it unable to use as the result.
-- Fixed the issue which caused a deploy error when an attempt was made to deploy a flow to heroku.
+- Fixed the issue that caused the deploy-to-heroku attempt to fail because [the default version of Node.js on Heroku was updated to 10](https://devcenter.heroku.com/changelog-items/1508) by specifying the Node.js version to 8.12 when enebular deploys a flow to Heroku.
 
 ### Changed
 

--- a/ja/Releases/enebular/2.5.3.md
+++ b/ja/Releases/enebular/2.5.3.md
@@ -11,7 +11,7 @@ lastUpdated: 2018-11-09
 ## Fixed
 
 - InfoMotion ダッシュボードのカレンダーをダブルクリック等で操作するとカレンダー部分が空白となり使用できなくなる不具合を修正しました
-- FlowをHerokuにデプロイする際、デプロイエラーが出ていた問題を修正しました
+- [HerokuにおいてNode.jsのデフォルトバージョンが10となったため](https://devcenter.heroku.com/changelog-items/1508)、FlowのHerokuへのデプロイがエラーとなる問題を修正しました。enebularからHerokuへのフローデプロイ時には、Node.jsのバージョンは8.12を使用するように指定しています
 
 ## Changed
 

--- a/ja/Releases/index.md
+++ b/ja/Releases/index.md
@@ -13,7 +13,7 @@ lastUpdated: 2018-11-09
 ### Fixed
 
 - InfoMotion ダッシュボードのカレンダーをダブルクリック等で操作するとカレンダー部分が空白となり使用できなくなる不具合を修正しました
-- FlowをHerokuにデプロイする際、デプロイエラーが出ていた問題を修正しました
+- [HerokuにおいてNode.jsのデフォルトバージョンが10となったため](https://devcenter.heroku.com/changelog-items/1508)、FlowのHerokuへのデプロイがエラーとなる問題を修正しました。enebularからHerokuへのフローデプロイ時には、Node.jsのバージョンは8.12を使用するように指定しています
 
 ### Changed
 


### PR DESCRIPTION
…ified the version of node-red which should be running on heroku when flow is deployed.